### PR TITLE
Fix crash on nodes <18.16.0 or 19.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"url": "https://github.com/echogarden-project/echogarden/issues"
 	},
 	"engines": {
-		"node": ">=18"
+		"node": ">=18.16.0 <19.0.0 || >=19.8.0"
 	},
 	"os": [
 		"win32",


### PR DESCRIPTION
Node 18 didn't get Buffer.copyBytesFrom until 18.16.0, and node 19 didn't get it until 19.8.  It's in 20.

Update the node versions specified in package.json so that users with a version higher than 18 but lower than 18.16 can more easily figure out what's wrong.  It's also nice to be accurate with our dependency versions :-D