### PR TITLE
Export supported languages for WhisperSTT

### DIFF
--- a/src/recognition/WhisperSTT.ts
+++ b/src/recognition/WhisperSTT.ts
@@ -1827,7 +1827,7 @@ export const modelNameToPackageName: { [modelName in WhisperModelName]: string }
 
 export const tokenizerPackageName = 'whisper-tokenizer'
 
-const languageIdLookup: { [s: string]: number } = {
+export const languageIdLookup: { [s: string]: number } = {
 	'en': 0,
 	'zh': 1,
 	'de': 2,


### PR DESCRIPTION
To know if you should call WhisperSTT beforehand within Node.js, without getting the "not supported" error