### PR TITLE
fix: case issue in main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"darwin",
 		"linux"
 	],
-	"main": "./dist/API/API.js",
+	"main": "./dist/api/API.js",
 	"type": "module",
 	"files": [
 		"src",


### PR DESCRIPTION
Update package.json with case sensitive correct path. Without this change this module fails to load on case sensitive file systems:

before:

```
> require("echogarden")
Uncaught:
Error: Cannot find module '/..../node_modules/echogarden/dist/API/API.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:491:19)
    at Function._findPath (node:internal/modules/cjs/loader:792:18)
    at Function._resolveFilename (node:internal/modules/cjs/loader:1232:27)
    at Function._load (node:internal/modules/cjs/loader:1072:27)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:216:24)
    at Module.require (node:internal/modules/cjs/loader:1337:12)
    at require (node:internal/modules/helpers:139:16) {
  code: 'MODULE_NOT_FOUND',
```

after:
```
> require("echogarden")
[Module: null prototype] {
  Client: [class Client],
  TranscriptAndTranslationAlignmentEngines: [
    {
```

(works)
