### PR TITLE
Fix JSON5 module import, allowing multiple values for --dtw.windowDuration to work

### DIFF
--- a/src/utilities/Utilities.ts
+++ b/src/utilities/Utilities.ts
@@ -158,7 +158,8 @@ export function printMatrix(matrix: Float32Array[]) {
 
 export async function parseJson(jsonText: string, useJson5 = false) {
 	if (useJson5) {
-		const JSON5 = await import('json5')
+		const json5Module: any = await import('json5')
+		const JSON5 = json5Module.default ?? json5Module
 
 		return JSON5.parse(jsonText)
 	} else {
@@ -170,7 +171,8 @@ export async function stringifyAndFormatJson(obj: any, useJson5 = false) {
 	let textContent: string
 
 	if (useJson5) {
-		const JSON5 = await import('json5')
+		const json5Module: any = await import('json5')
+		const JSON5 = json5Module.default ?? json5Module
 
 		textContent = JSON5.stringify(obj, undefined, 4)
 	} else {


### PR DESCRIPTION
Fixes this issue: https://github.com/echogarden-project/echogarden/issues/113

When passing array/union options via the CLI (e.g. `align.dtw.windowDuration=["30%","25%"]`),  
Echogarden silently failes to parse the value as JSON5 and falls back to treating it as a raw  
string, producing an error like:

> Error: A DTW window duration, when provided as a string, must be formatted as an integer  
> percentage value like '15%'.

The root cause: `json5@2.2.3` is a CommonJS module. When loaded via ESM dynamic import  
(`await import('json5')`), the exports come through as `{ default: { parse, stringify } }`  
rather than at the top level — so `JSON5.parse` was `undefined`.

Fixed by applying the standard CJS/ESM interop pattern in `parseJson` and `stringifyAndFormatJson`:

```ts
const json5Module = await import('json5')
const JSON5 = json5Module.default ?? json5Module
```